### PR TITLE
Add Python adsorbate tracking pipeline with GUI

### DIFF
--- a/Readme
+++ b/Readme
@@ -6,6 +6,11 @@ Python implementation of the AFM adsorbate tracking and diffusion analysis pipel
 - `analyze_adsorbate_diffusion`: runs lattice locking and drift-corrected diffusion analysis, mirroring the MATLAB workflow.
 - `launch_gui`: a Tkinter GUI for selecting input data and configurable parameters.
 
+## Requirements
+
+- Python 3.12 (tested with Python 3.12.10)
+- Third-party packages: `numpy`, `scipy`, `imageio` (install `imageio-ffmpeg` for MP4 export support)
+
 ## Usage
 
 ```bash

--- a/Readme
+++ b/Readme
@@ -1,1 +1,32 @@
-temp
+# Track Adsorbates AFM
+
+Python implementation of the AFM adsorbate tracking and diffusion analysis pipeline. The package includes:
+
+- `simple_lattice_occupancy`: locks the lattice, classifies adsorbate sites, and exports artificial-lattice videos.
+- `analyze_adsorbate_diffusion`: runs lattice locking and drift-corrected diffusion analysis, mirroring the MATLAB workflow.
+- `launch_gui`: a Tkinter GUI for selecting input data and configurable parameters.
+
+## Usage
+
+```bash
+python -m track_adsorbates.ui
+```
+
+The GUI allows selecting a video file (or folder + filename) and entering lattice parameters. After analysis completes, diffusion statistics are displayed and saved to `<video>_diffusion_results.mat` alongside auxiliary exports.
+
+For scripted use:
+
+```python
+from track_adsorbates import analyze_adsorbate_diffusion
+
+results = analyze_adsorbate_diffusion(
+    "path/to/video.mp4",
+    vid_width_nm=10.0,
+    ax_a=3.0,
+    ay_a=3.0,
+    gamma_deg_guess=60.0,
+)
+print(results.D)
+```
+
+All outputs mirror the MATLAB originals, including artificial-lattice videos, per-frame occupancy data (`lattice_occupancy_locked.mat`), and diffusion statistics.

--- a/track_adsorbates/__init__.py
+++ b/track_adsorbates/__init__.py
@@ -1,0 +1,11 @@
+"""High-level APIs for adsorbate tracking and diffusion analysis."""
+
+from .analysis import analyze_adsorbate_diffusion
+from .simple_lattice import simple_lattice_occupancy
+from .ui import launch_gui
+
+__all__ = [
+    "analyze_adsorbate_diffusion",
+    "simple_lattice_occupancy",
+    "launch_gui",
+]

--- a/track_adsorbates/analysis.py
+++ b/track_adsorbates/analysis.py
@@ -1,0 +1,269 @@
+"""Diffusion analysis pipeline for adsorbate tracking."""
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import numpy as np
+from scipy.io import savemat
+
+from .helpers import (
+    binary_corr,
+    integer_shift,
+    nm_cover_image,
+    remove_matches,
+    reorder_by_nearest,
+)
+from .simple_lattice import FrameBundle, simple_lattice_occupancy
+
+
+@dataclass
+class DiffusionResults:
+    D: float
+    D_CI95: Tuple[float, float]
+    mean_d2_nm2: float
+    delta_t: float
+    N_steps: int
+    step_hist_counts: np.ndarray
+    step_order: np.ndarray
+    drift_nm: np.ndarray
+    drift_pix: np.ndarray
+    locked_basis_a1: np.ndarray
+    locked_basis_a2: np.ndarray
+    locked_params: Dict[str, float]
+
+    def to_dict(self) -> Dict[str, object]:
+        data = asdict(self)
+        a1 = data.pop("locked_basis_a1")
+        a2 = data.pop("locked_basis_a2")
+        data["locked_basis"] = {"a1": a1, "a2": a2}
+        data["locked_params"] = self.locked_params
+        data["step_hist_counts"] = {
+            "dn": self.step_order[:, 0],
+            "dm": self.step_order[:, 1],
+            "count": self.step_hist_counts,
+        }
+        return data
+
+
+def analyze_adsorbate_diffusion(
+    vid_path: str | Path,
+    vid_width_nm: float,
+    ax_a: float,
+    ay_a: float,
+    gamma_deg_guess: float,
+    *,
+    probe_diam_a: float | None = None,
+    max_frames: int | None = None,
+) -> DiffusionResults:
+    """Run the full adsorbate diffusion analysis pipeline."""
+    bundle = simple_lattice_occupancy(
+        vid_path,
+        vid_width_nm,
+        ax_a,
+        ay_a,
+        gamma_deg_guess,
+        probe_diam_a=probe_diam_a,
+        max_frames=max_frames,
+    )
+
+    vid_path = Path(vid_path)
+    folder = vid_path.parent if vid_path.parent != Path("") else Path.cwd()
+    base = vid_path.stem
+
+    a1 = bundle.ax_star * np.array([np.cos(np.radians(bundle.theta_star)), np.sin(np.radians(bundle.theta_star))])
+    a2 = bundle.ay_star * np.array(
+        [
+            np.cos(np.radians(bundle.theta_star + bundle.gamma_star)),
+            np.sin(np.radians(bundle.theta_star + bundle.gamma_star)),
+        ]
+    )
+
+    phi0 = np.array([0.5, 0.5])
+    base0 = np.array([1.0, 1.0]) + phi0[0] * a1 + phi0[1] * a2
+    n_range, m_range = nm_cover_image(bundle.frame_shape, base0, a1, a2, bundle.params.cover_margin)
+    nn_glob, mm_glob = np.meshgrid(n_range, m_range)
+    nn_vec = nn_glob.ravel()
+    mm_vec = mm_glob.ravel()
+    nmin = n_range[0]
+    mmin = m_range[0]
+    Ln = len(n_range)
+    Lm = len(m_range)
+
+    occ_mats: List[np.ndarray] = []
+    for frame in bundle.occ_frames:
+        occ_matrix = _reconstruct_occupancy(
+            frame,
+            nn_vec,
+            mm_vec,
+            nmin,
+            mmin,
+            Ln,
+            Lm,
+            a1,
+            a2,
+            bundle.frame_shape,
+        )
+        occ_mats.append(occ_matrix)
+
+    neighbor_shifts = np.array(
+        [
+            [-1, -1],
+            [-1, 0],
+            [-1, 1],
+            [0, -1],
+            [0, 0],
+            [0, 1],
+            [1, -1],
+            [1, 0],
+            [1, 1],
+        ]
+    )
+
+    pair_shift = np.zeros((len(occ_mats) - 1, 2), dtype=int)
+    for k in range(len(occ_mats) - 1):
+        O1 = occ_mats[k]
+        O2 = occ_mats[k + 1]
+        best_score = -np.inf
+        best_shift = np.array([0, 0])
+        for dn, dm in neighbor_shifts:
+            score = binary_corr(O1, O2, dn, dm)
+            if score > best_score:
+                best_score = score
+                best_shift = np.array([dn, dm])
+        pair_shift[k] = best_shift
+
+    drift_nm = np.zeros((len(occ_mats), 2), dtype=int)
+    for k in range(1, len(occ_mats)):
+        drift_nm[k] = drift_nm[k - 1] + pair_shift[k - 1]
+    drift_pix = np.column_stack(
+        [
+            drift_nm[:, 0] * a1[0] + drift_nm[:, 1] * a2[0],
+            drift_nm[:, 0] * a1[1] + drift_nm[:, 1] * a2[1],
+        ]
+    )
+
+    occ_aligned = []
+    for k, occ in enumerate(occ_mats):
+        dn, dm = -drift_nm[k]
+        occ_aligned.append(integer_shift(occ, dn, dm))
+
+    step_order = np.array(
+        [
+            [0, 0],
+            [-1, 0],
+            [1, 0],
+            [0, -1],
+            [0, 1],
+            [-1, -1],
+            [-1, 1],
+            [1, -1],
+            [1, 1],
+        ]
+    )
+    step_counts = np.zeros(len(step_order), dtype=int)
+
+    S1 = 0.0
+    S2 = 0.0
+    N_steps = 0
+
+    for k in range(len(occ_aligned) - 1):
+        A = occ_aligned[k].copy()
+        B = occ_aligned[k + 1].copy()
+        for idx, (dn, dm) in enumerate(step_order):
+            shifted = integer_shift(B, dn, dm)
+            overlap = A & shifted
+            c = int(np.sum(overlap))
+            if c == 0:
+                continue
+            A[overlap] = False
+            B = remove_matches(B, overlap, dn, dm)
+            dvec = dn * a1 + dm * a2
+            d2 = float(np.dot(dvec, dvec))
+            S1 += c * d2
+            S2 += c * (d2**2)
+            N_steps += c
+            step_counts[idx] += c
+
+    delta_t = 1.0 / bundle.fps
+    if N_steps > 1:
+        mean_d2 = S1 / N_steps
+        var_d2 = max(0.0, S2 / N_steps - mean_d2**2)
+        se_d2 = np.sqrt(var_d2 / N_steps)
+        nm_per_px = bundle.nm_per_px
+        mean_d2_nm2 = (nm_per_px**2) * mean_d2
+        se_d2_nm2 = (nm_per_px**2) * se_d2
+        D = mean_d2_nm2 / (4 * delta_t)
+        D_lo = (mean_d2_nm2 - 1.96 * se_d2_nm2) / (4 * delta_t)
+        D_hi = (mean_d2_nm2 + 1.96 * se_d2_nm2) / (4 * delta_t)
+    else:
+        mean_d2_nm2 = float("nan")
+        D = float("nan")
+        D_lo = float("nan")
+        D_hi = float("nan")
+
+    results = DiffusionResults(
+        D=D,
+        D_CI95=(D_lo, D_hi),
+        mean_d2_nm2=mean_d2_nm2,
+        delta_t=delta_t,
+        N_steps=N_steps,
+        step_hist_counts=step_counts,
+        step_order=step_order,
+        drift_nm=drift_nm,
+        drift_pix=drift_pix,
+        locked_basis_a1=a1,
+        locked_basis_a2=a2,
+        locked_params={
+            "ax_px": bundle.ax_star,
+            "ay_px": bundle.ay_star,
+            "gamma_deg": bundle.gamma_star,
+            "theta_deg": bundle.theta_star,
+        },
+    )
+
+    out_path = folder / f"{base}_diffusion_results.mat"
+    savemat(out_path, {"results": results.to_dict()})
+
+    return results
+
+
+def _reconstruct_occupancy(
+    frame: FrameBundle,
+    nn_vec: np.ndarray,
+    mm_vec: np.ndarray,
+    nmin: int,
+    mmin: int,
+    Ln: int,
+    Lm: int,
+    a1: np.ndarray,
+    a2: np.ndarray,
+    frame_shape: Tuple[int, int],
+) -> np.ndarray:
+    phi = np.array(frame.phi_locked)
+    base = np.array([1.0, 1.0]) + phi[0] * a1 + phi[1] * a2
+    xy = np.column_stack(
+        [
+            base[0] + nn_vec * a1[0] + mm_vec * a2[0],
+            base[1] + nn_vec * a1[1] + mm_vec * a2[1],
+        ]
+    )
+    width = frame_shape[1]
+    height = frame_shape[0]
+    in_img = (
+        (xy[:, 0] >= 1)
+        & (xy[:, 0] <= width)
+        & (xy[:, 1] >= 1)
+        & (xy[:, 1] <= height)
+    )
+    occ_vec = frame.occ
+    if len(occ_vec) != np.sum(in_img):
+        occ_vec = reorder_by_nearest(frame.nodes_px_locked, xy[in_img], occ_vec)
+    n_idx = nn_vec[in_img] - nmin
+    m_idx = mm_vec[in_img] - mmin
+    occ_matrix = np.zeros((Lm, Ln), dtype=bool)
+    for val, ni, mi in zip(occ_vec > 0, n_idx, m_idx):
+        if 0 <= mi < Lm and 0 <= ni < Ln:
+            occ_matrix[mi, ni] = val
+    return occ_matrix

--- a/track_adsorbates/analysis.py
+++ b/track_adsorbates/analysis.py
@@ -32,6 +32,7 @@ class DiffusionResults:
     locked_basis_a1: np.ndarray
     locked_basis_a2: np.ndarray
     locked_params: Dict[str, float]
+    results_path: Path
 
     def to_dict(self) -> Dict[str, object]:
         data = asdict(self)
@@ -44,6 +45,7 @@ class DiffusionResults:
             "dm": self.step_order[:, 1],
             "count": self.step_hist_counts,
         }
+        data["results_path"] = str(data["results_path"])
         return data
 
 
@@ -69,7 +71,7 @@ def analyze_adsorbate_diffusion(
     )
 
     vid_path = Path(vid_path)
-    folder = vid_path.parent if vid_path.parent != Path("") else Path.cwd()
+    results_dir = bundle.results_dir
     base = vid_path.stem
 
     a1 = bundle.ax_star * np.array([np.cos(np.radians(bundle.theta_star)), np.sin(np.radians(bundle.theta_star))])
@@ -203,6 +205,8 @@ def analyze_adsorbate_diffusion(
         D_lo = float("nan")
         D_hi = float("nan")
 
+    out_path = results_dir / f"{base}_diffusion_results.mat"
+
     results = DiffusionResults(
         D=D,
         D_CI95=(D_lo, D_hi),
@@ -221,9 +225,9 @@ def analyze_adsorbate_diffusion(
             "gamma_deg": bundle.gamma_star,
             "theta_deg": bundle.theta_star,
         },
+        results_path=out_path,
     )
 
-    out_path = folder / f"{base}_diffusion_results.mat"
     savemat(out_path, {"results": results.to_dict()})
 
     return results

--- a/track_adsorbates/helpers.py
+++ b/track_adsorbates/helpers.py
@@ -1,0 +1,299 @@
+"""Shared helper utilities for adsorbate tracking."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence, Tuple
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+from scipy.ndimage import gaussian_filter, maximum_filter
+
+
+Array2D = NDArray[np.float64]
+BoolArray2D = NDArray[np.bool_]
+
+
+@dataclass
+class NeighborShift:
+    dn: int
+    dm: int
+
+
+def nm_cover_image(
+    size_hw: Tuple[int, int],
+    base: NDArray[np.float64],
+    a1: NDArray[np.float64],
+    a2: NDArray[np.float64],
+    margin: int,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Return ranges of integer lattice indices that cover an image."""
+    h, w = size_hw
+    A = np.column_stack([a1, a2])
+    if np.linalg.matrix_rank(A) < 2:
+        return np.arange(-1, 2), np.arange(-1, 2)
+    corners = np.array([[1, 1, w, w], [1, h, 1, h]], dtype=float)
+    q = np.linalg.lstsq(A, corners - base[:, None], rcond=None)[0]
+    nmin = int(np.floor(np.min(q[0])) - margin)
+    nmax = int(np.ceil(np.max(q[0])) + margin)
+    mmin = int(np.floor(np.min(q[1])) - margin)
+    mmax = int(np.ceil(np.max(q[1])) + margin)
+    return np.arange(nmin, nmax + 1), np.arange(mmin, mmax + 1)
+
+
+def reorder_by_nearest(
+    stored: NDArray[np.float64],
+    recomputed: NDArray[np.float64],
+    occ_vec: NDArray[np.float64],
+) -> NDArray[np.float64]:
+    """Reorder occupancy values by nearest-neighbour matching."""
+    if stored.size == 0 or recomputed.size == 0:
+        return np.zeros(len(recomputed), dtype=float)
+    used = np.zeros(len(stored), dtype=bool)
+    out = np.zeros(len(recomputed), dtype=float)
+    for i, target in enumerate(recomputed):
+        d2 = np.sum((stored - target) ** 2, axis=1)
+        d2[used] = np.inf
+        j = int(np.argmin(d2))
+        used[j] = True
+        out[i] = occ_vec[j] if j < len(occ_vec) else 0
+    return out
+
+
+def binary_corr(A: BoolArray2D, B: BoolArray2D, dn: int, dm: int) -> int:
+    """Binary correlation score between lattice-aligned frames."""
+    if dn == 0 and dm == 0:
+        overlap_a = A
+        overlap_b = B
+    else:
+        slc_a, slc_b = _shift_overlap_slices(A.shape, dn, dm)
+        if slc_a is None:
+            return 0
+        overlap_a = A[slc_a]
+        overlap_b = B[slc_b]
+    return int(np.sum(overlap_a & overlap_b))
+
+
+def integer_shift(B: BoolArray2D, dn: int, dm: int) -> BoolArray2D:
+    """Shift a boolean matrix by integer lattice steps."""
+    h, w = B.shape
+    out = np.zeros_like(B)
+    slc_src, slc_dst = _shift_slices(B.shape, dn, dm)
+    if slc_src is not None:
+        out[slc_dst] = B[slc_src]
+    return out
+
+
+def logical_and_overlap(A: BoolArray2D, B: BoolArray2D) -> BoolArray2D:
+    """Return element-wise AND on the overlapping region of two arrays."""
+    h = min(A.shape[0], B.shape[0])
+    w = min(A.shape[1], B.shape[1])
+    return A[:h, :w] & B[:h, :w]
+
+
+def remove_matches(B: BoolArray2D, mask_on_a: BoolArray2D, dn: int, dm: int) -> BoolArray2D:
+    """Remove matched entries from ``B`` corresponding to shift ``(dn, dm)``."""
+    shifted = integer_shift(mask_on_a, -dn, -dm)
+    shifted = shifted[: B.shape[0], : B.shape[1]]
+    out = B.copy()
+    out[shifted] = False
+    return out
+
+
+def enhance_dog(image: Array2D, sigma_lo: float, sigma_hi: float) -> Array2D:
+    """Enhance high-frequency features using a difference-of-Gaussians filter."""
+    low = gaussian_filter(image, sigma_lo)
+    high = gaussian_filter(image, sigma_hi)
+    diff = np.clip(low - high, a_min=0, a_max=None)
+    return rescale(diff)
+
+
+def rescale(image: Array2D) -> Array2D:
+    """Linearly rescale image to [0, 1]."""
+    mn = np.min(image)
+    mx = np.max(image)
+    if not np.isfinite(mn) or not np.isfinite(mx) or mx <= mn:
+        return np.zeros_like(image)
+    return (image - mn) / (mx - mn)
+
+
+def sample_at_points(image: Array2D, pts: NDArray[np.float64]) -> NDArray[np.float64]:
+    """Bilinear sampling of ``image`` at floating-point coordinates ``pts``."""
+    if len(pts) == 0:
+        return np.empty(0)
+    h, w = image.shape
+    x = np.clip(pts[:, 0], 1, w) - 1
+    y = np.clip(pts[:, 1], 1, h) - 1
+    x0 = np.floor(x).astype(int)
+    y0 = np.floor(y).astype(int)
+    x1 = np.clip(x0 + 1, 0, w - 1)
+    y1 = np.clip(y0 + 1, 0, h - 1)
+    a = x - x0
+    b = y - y0
+    vals = (
+        (1 - a) * (1 - b) * image[y0, x0]
+        + a * (1 - b) * image[y0, x1]
+        + (1 - a) * b * image[y1, x0]
+        + a * b * image[y1, x1]
+    )
+    return vals
+
+
+def draw_spots(image: Array2D, pts: NDArray[np.float64], radius: int, value: float) -> Array2D:
+    out = image.copy()
+    h, w = out.shape
+    r = max(1, int(round(radius)))
+    for cx, cy in pts:
+        xmin = max(0, int(np.floor(cx - r)))
+        xmax = min(w - 1, int(np.ceil(cx + r)))
+        ymin = max(0, int(np.floor(cy - r)))
+        ymax = min(h - 1, int(np.ceil(cy + r)))
+        if xmin > xmax or ymin > ymax:
+            continue
+        xs = np.arange(xmin, xmax + 1)
+        ys = np.arange(ymin, ymax + 1)
+        xx, yy = np.meshgrid(xs, ys)
+        mask = (xx - cx) ** 2 + (yy - cy) ** 2 <= r**2
+        block = out[ymin : ymax + 1, xmin : xmax + 1]
+        block[mask] = value
+        out[ymin : ymax + 1, xmin : xmax + 1] = block
+    return out
+
+
+def angle_between_deg(u: NDArray[np.float64], v: NDArray[np.float64]) -> float:
+    nu = np.linalg.norm(u)
+    nv = np.linalg.norm(v)
+    if nu == 0 or nv == 0:
+        return np.nan
+    c = np.clip(np.dot(u, v) / (nu * nv), -1.0, 1.0)
+    return float(np.degrees(np.arccos(c)))
+
+
+def angle_diff_deg(a: float, b: float) -> float:
+    a = np.mod(a, 180.0)
+    b = np.mod(b, 180.0)
+    d = abs(a - b)
+    return float(min(d, 180.0 - d))
+
+
+def angle_mode_deg(vals: Sequence[float], bin_size_deg: float) -> float:
+    valid = np.array([v for v in vals if np.isfinite(v)], dtype=float)
+    if valid.size == 0:
+        return float("nan")
+    vals_mod = np.mod(valid, 180.0)
+    edges = np.arange(0, 180 + bin_size_deg, bin_size_deg)
+    counts, edges = np.histogram(vals_mod, edges)
+    idx = int(np.argmax(counts))
+    mask = (vals_mod >= edges[idx]) & (vals_mod < edges[idx + 1])
+    return circ_mean_deg(vals_mod[mask])
+
+
+def circ_mean_deg(angles_deg: ArrayLike) -> float:
+    if len(angles_deg) == 0:
+        return float("nan")
+    angles_rad = np.deg2rad(np.mod(angles_deg, 180.0))
+    z = np.mean(np.exp(1j * 2 * angles_rad))
+    return float(np.mod(np.degrees(0.5 * np.angle(z)), 180.0))
+
+
+def length_mode_px(lengths: Sequence[float]) -> float:
+    valid = np.array([v for v in lengths if np.isfinite(v) and v > 0], dtype=float)
+    if valid.size == 0:
+        return float("nan")
+    if valid.size == 1:
+        return float(valid[0])
+    bw = max(0.5, 2 * (np.percentile(valid, 75) - np.percentile(valid, 25)) / (len(valid) ** (1 / 3)))
+    edges = np.arange(valid.min() - bw, valid.max() + 2 * bw, bw)
+    counts, edges = np.histogram(valid, edges)
+    idx = int(np.argmax(counts))
+    mask = (valid >= edges[idx]) & (valid < edges[idx + 1])
+    return float(np.mean(valid[mask]))
+
+
+def local_maxima_mask(magnitude: Array2D) -> BoolArray2D:
+    """Binary mask of local maxima using a 3x3 footprint."""
+    filtered = maximum_filter(magnitude, size=3, mode="nearest")
+    return (magnitude == filtered) & (magnitude > 0)
+
+
+def kmeans_1d(data: NDArray[np.float64], k: int, max_iter: int = 100) -> Tuple[np.ndarray, np.ndarray]:
+    if data.size < k:
+        raise ValueError("Not enough data for k-means clustering")
+    # initialise centroids using quantiles
+    percentiles = np.linspace(0, 100, k + 2)[1:-1]
+    centroids = np.percentile(data, percentiles)
+    labels = np.zeros(data.shape, dtype=int)
+    for _ in range(max_iter):
+        distances = np.abs(data[:, None] - centroids[None, :])
+        new_labels = np.argmin(distances, axis=1)
+        if np.array_equal(labels, new_labels):
+            break
+        labels = new_labels
+        for idx in range(k):
+            mask = labels == idx
+            if np.any(mask):
+                centroids[idx] = np.mean(data[mask])
+    return labels, centroids
+
+
+def gaussian_fft_peaks(
+    image: Array2D,
+    r1: float,
+    r2: float,
+    slack: float,
+    top_k: int,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Harvest prominent peaks from the FFT magnitude image."""
+    h, w = image.shape
+    fft = np.fft.fftshift(np.fft.fft2(image - np.mean(image)))
+    magnitude = np.abs(fft)
+    yy, xx = np.indices((h, w))
+    cx = (w - 1) / 2
+    cy = (h - 1) / 2
+    gx = (xx - cx) / w
+    gy = (yy - cy) / h
+    radius = np.hypot(gx, gy)
+    mask = radius <= 2.0 / min(h, w)
+    magnitude[mask] = 0
+    peaks = local_maxima_mask(magnitude)
+    band_min = min(r1 * (1 - slack), r2 * (1 - slack))
+    band_max = max(r1 * (1 + slack), r2 * (1 + slack))
+    candidate_mask = peaks & (radius >= band_min) & (radius <= band_max)
+    coords = np.column_stack(np.nonzero(candidate_mask))
+    values = magnitude[candidate_mask]
+    if values.size == 0:
+        return magnitude, np.empty((0, 2)), np.empty(0)
+    order = np.argsort(values)[::-1][:top_k]
+    coords = coords[order]
+    values = values[order]
+    freqs = np.column_stack(((coords[:, 1] - cx) / w, (coords[:, 0] - cy) / h))
+    return magnitude, freqs, values
+
+
+def _shift_overlap_slices(shape: Tuple[int, int], dn: int, dm: int):
+    h, w = shape
+    c1 = max(0, -dn)
+    c2 = min(w, w - dn)
+    r1 = max(0, -dm)
+    r2 = min(h, h - dm)
+    if c1 >= c2 or r1 >= r2:
+        return None, None
+    slc_a = np.s_[r1:r2, c1:c2]
+    slc_b = np.s_[r1 + dm : r2 + dm, c1 + dn : c2 + dn]
+    return slc_a, slc_b
+
+
+def _shift_slices(shape: Tuple[int, int], dn: int, dm: int):
+    h, w = shape
+    src_c1 = max(0, dn)
+    src_c2 = min(w, w + dn)
+    src_r1 = max(0, dm)
+    src_r2 = min(h, h + dm)
+    dst_c1 = max(0, -dn)
+    dst_c2 = min(w, w - dn)
+    dst_r1 = max(0, -dm)
+    dst_r2 = min(h, h - dm)
+    if src_c1 >= src_c2 or src_r1 >= src_r2:
+        return None, None
+    src_slice = np.s_[src_r1:src_r2, src_c1:src_c2]
+    dst_slice = np.s_[dst_r1:dst_r2, dst_c1:dst_c2]
+    return src_slice, dst_slice

--- a/track_adsorbates/simple_lattice.py
+++ b/track_adsorbates/simple_lattice.py
@@ -379,8 +379,8 @@ def simple_lattice_occupancy(
         combo = np.clip(combo, 0, 1)
         combo_rgb = np.repeat((combo * 255).astype(np.uint8)[..., None], 3, axis=2)
 
-        side_writer.write(combo_rgb)
-        only_writer.write(art_rgb)
+        side_writer.append_data(combo_rgb)
+        only_writer.append_data(art_rgb)
 
         bundle = FrameBundle(
             nodes_px_locked=xy_lock_in,

--- a/track_adsorbates/simple_lattice.py
+++ b/track_adsorbates/simple_lattice.py
@@ -86,6 +86,7 @@ class BundleOutputs:
     canvas_width: int
     shift_canvas: Tuple[int, int]
     frame_shape: Tuple[int, int]
+    results_dir: Path
 
 
 def simple_lattice_occupancy(
@@ -108,6 +109,8 @@ def simple_lattice_occupancy(
     vid_path = Path(vid_path)
     folder = vid_path.parent if vid_path.parent != Path("") else Path.cwd()
     base = vid_path.stem
+    results_dir = folder / f"{base}_results"
+    results_dir.mkdir(parents=True, exist_ok=True)
 
     reader = imageio.get_reader(str(vid_path))
     meta = reader.get_meta_data()
@@ -237,10 +240,10 @@ def simple_lattice_occupancy(
     canvas_height = max(1, max_yc - min_yc + 1)
     shift_canvas = (min_xc, min_yc)
 
-    sxspath = str(folder / f"{base}_artificial_lattice_SxS.mp4")
-    onlypath = str(folder / f"{base}_artificial_lattice_only.mp4")
-    side_writer = imageio.get_writer(sxspath, fps=fps)
-    only_writer = imageio.get_writer(onlypath, fps=fps)
+    sxspath = results_dir / f"{base}_artificial_lattice_SxS.mp4"
+    onlypath = results_dir / f"{base}_artificial_lattice_only.mp4"
+    side_writer = imageio.get_writer(str(sxspath), fps=fps)
+    only_writer = imageio.get_writer(str(onlypath), fps=fps)
 
     occ_frames: List[FrameBundle] = []
     prev_phi = np.array([0.5, 0.5])
@@ -352,7 +355,14 @@ def simple_lattice_occupancy(
         if xy_canvas.size:
             art = draw_spots(art, xy_canvas, r_spot_locked, params.gray_dark)
             if np.any(in_img) and np.any(occ_in == 1):
-                art = draw_spots(art, xy_canvas[in_img & (occ_in == 1)], r_spot_locked, params.gray_light)
+                highlight_mask = np.zeros(len(xy_canvas), dtype=bool)
+                highlight_mask[in_img] = occ_in == 1
+                art = draw_spots(
+                    art,
+                    xy_canvas[highlight_mask],
+                    r_spot_locked,
+                    params.gray_light,
+                )
         art = np.clip(art, 0, 1)
         art_rgb = np.repeat((art * 255).astype(np.uint8)[..., None], 3, axis=2)
 
@@ -391,8 +401,8 @@ def simple_lattice_occupancy(
     png_a = None
     png_p = None
     if params.export_fwhm_hists and fwhm_all_px:
-        png_a = str(folder / f"{base}_fwhm_hist_A.png")
-        png_p = str(folder / f"{base}_fwhm_hist_px.png")
+        png_a = str(results_dir / f"{base}_fwhm_hist_A.png")
+        png_p = str(results_dir / f"{base}_fwhm_hist_px.png")
         _save_histogram(np.array(fwhm_all_a), "FWHM (Å)", png_a, base)
         _save_histogram(np.array(fwhm_all_px), "FWHM (px)", png_p, base)
 
@@ -422,8 +432,8 @@ def simple_lattice_occupancy(
         "ay_px_guess": ay_px_guess,
         "nm_per_px": nm_per_px,
         "occFrames": np.array(occ_serialised, dtype=object),
-        "sxspath": sxspath,
-        "onlypath": onlypath,
+        "sxspath": str(sxspath),
+        "onlypath": str(onlypath),
         "ax_star": ax_star,
         "ay_star": ay_star,
         "gamma_star": gamma_star,
@@ -436,8 +446,9 @@ def simple_lattice_occupancy(
         "Wc": canvas_width,
         "shiftCanvas": np.array(shift_canvas),
         "frame_shape": np.array([height, width]),
+        "results_dir": str(results_dir),
     }
-    savemat(folder / "lattice_occupancy_locked.mat", data)
+    savemat(results_dir / "lattice_occupancy_locked.mat", data)
 
     return BundleOutputs(
         occ_frames=occ_frames,
@@ -448,8 +459,8 @@ def simple_lattice_occupancy(
         gamma_star=gamma_star,
         theta_star=theta_star,
         nm_per_px=nm_per_px,
-        sxspath=sxspath,
-        onlypath=onlypath,
+        sxspath=str(sxspath),
+        onlypath=str(onlypath),
         fwhm_all_px=np.array(fwhm_all_px),
         fwhm_all_a=np.array(fwhm_all_a),
         png_a=png_a,
@@ -458,6 +469,7 @@ def simple_lattice_occupancy(
         canvas_width=canvas_width,
         shift_canvas=shift_canvas,
         frame_shape=(height, width),
+        results_dir=results_dir,
     )
 
 

--- a/track_adsorbates/simple_lattice.py
+++ b/track_adsorbates/simple_lattice.py
@@ -1,0 +1,680 @@
+"""Python port of the `simple_lattice_occupancy` routine."""
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+import imageio
+import imageio.v3 as iio
+import numpy as np
+from scipy.io import savemat
+
+from .helpers import (
+    angle_between_deg,
+    angle_diff_deg,
+    angle_mode_deg,
+    draw_spots,
+    enhance_dog,
+    gaussian_fft_peaks,
+    kmeans_1d,
+    length_mode_px,
+    nm_cover_image,
+    rescale,
+    sample_at_points,
+)
+from .helpers import integer_shift
+
+
+@dataclass
+class LatticeParams:
+    gauss_lo_hi: Tuple[float, float] = (0.8, 3.0)
+    ring_slack_scan: float = 0.40
+    top_k_per_band: int = 140
+    wiggle_pct: float = 0.05
+    min_tol_deg: float = 2.0
+    phase_grid: int = 18
+    spot_radius_frac: float = 0.25
+    gray_dark: float = 0.30
+    gray_light: float = 0.85
+    max_sites_per_frame: int = 30000
+    ad_percentile: float = 75.0
+    z_pos_thresh: float = 0.25
+    min_occ_for_frame: int = 3
+    fallback_min_pct: float = 50.0
+    fallback_step: int = 5
+    top_frac_rescue: float = 0.03
+    top_min_rescue: int = 5
+    cover_margin: int = 3
+    fwhm_probe_diam_a: float = 1.5
+    fwhm_dr_px: float = 0.5
+    fwhm_outer_frac: float = 0.3
+    export_fwhm_hists: bool = True
+    max_frames: int | None = None
+
+
+@dataclass
+class FrameBundle:
+    nodes_px_locked: np.ndarray
+    nodes_px_measured: np.ndarray
+    occ: np.ndarray
+    fwhm_px: np.ndarray
+    a_len_px_pf: Tuple[float, float]
+    a_len_px_locked: Tuple[float, float]
+    r_spot: int
+    phi_pf: Tuple[float, float]
+    phi_locked: Tuple[float, float]
+
+
+@dataclass
+class BundleOutputs:
+    occ_frames: List[FrameBundle]
+    fps: float
+    params: LatticeParams
+    ax_star: float
+    ay_star: float
+    gamma_star: float
+    theta_star: float
+    nm_per_px: float
+    sxspath: str
+    onlypath: str
+    fwhm_all_px: np.ndarray
+    fwhm_all_a: np.ndarray
+    png_a: str | None
+    png_p: str | None
+    canvas_height: int
+    canvas_width: int
+    shift_canvas: Tuple[int, int]
+    frame_shape: Tuple[int, int]
+
+
+def simple_lattice_occupancy(
+    vid_path: str | Path,
+    vid_width_nm: float,
+    ax_a: float,
+    ay_a: float,
+    gamma_deg_guess: float,
+    *,
+    probe_diam_a: float | None = None,
+    max_frames: int | None = None,
+) -> BundleOutputs:
+    """Port of the MATLAB ``simple_lattice_occupancy`` routine."""
+    params = LatticeParams()
+    if probe_diam_a is not None:
+        params.fwhm_probe_diam_a = probe_diam_a
+    if max_frames is not None:
+        params.max_frames = max_frames
+
+    vid_path = Path(vid_path)
+    folder = vid_path.parent if vid_path.parent != Path("") else Path.cwd()
+    base = vid_path.stem
+
+    reader = imageio.get_reader(str(vid_path))
+    meta = reader.get_meta_data()
+    fps = float(meta.get("fps", meta.get("fps_numerator", 1)) / max(meta.get("fps_denominator", 1), 1))
+    if not np.isfinite(fps) or fps <= 0:
+        fps = float(meta.get("fps", 1.0))
+    frames: List[np.ndarray] = []
+    for idx, frame in enumerate(reader):
+        if params.max_frames is not None and idx >= params.max_frames:
+            break
+        if frame.ndim == 3:
+            frame = np.mean(frame[..., :3], axis=2)
+        frame = frame.astype(np.float64)
+        frame = rescale(frame)
+        frames.append(frame)
+    reader.close()
+    if not frames:
+        raise ValueError(f"No frames could be read from {vid_path}")
+    frames = [np.asarray(f, dtype=np.float64) for f in frames]
+    n_frames = len(frames)
+    height, width = frames[0].shape
+
+    nm_per_px = vid_width_nm / width
+    a_per_px = 10.0 * nm_per_px
+    px_per_a = 1.0 / a_per_px
+    ax_px_guess = ax_a * px_per_a
+    ay_px_guess = ay_a * px_per_a
+
+    theta_list = np.full(n_frames, np.nan)
+    gamma_list = np.full(n_frames, np.nan)
+    len_a1 = np.full(n_frames, np.nan)
+    len_a2 = np.full(n_frames, np.nan)
+
+    prev_g1: np.ndarray | None = None
+    prev_g2: np.ndarray | None = None
+
+    for i, image in enumerate(frames):
+        enh = enhance_dog(image, *params.gauss_lo_hi)
+        g1, g2 = _fft_pair_scan(
+            enh,
+            ax_px_guess,
+            ay_px_guess,
+            gamma_deg_guess,
+            params,
+        )
+        if g1 is None or g2 is None:
+            if prev_g1 is not None and prev_g2 is not None:
+                g1, g2 = prev_g1, prev_g2
+            else:
+                theta_guess = np.radians(0.0)
+                g1 = np.array([
+                    np.cos(theta_guess) / max(ax_px_guess, 1e-9),
+                    np.sin(theta_guess) / max(ax_px_guess, 1e-9),
+                ])
+                g2 = np.array([
+                    np.cos(theta_guess + np.radians(gamma_deg_guess))
+                    / max(ay_px_guess, 1e-9),
+                    np.sin(theta_guess + np.radians(gamma_deg_guess))
+                    / max(ay_px_guess, 1e-9),
+                ])
+        prev_g1, prev_g2 = g1, g2
+        lattice = np.linalg.pinv(np.vstack([g1, g2]))
+        a1 = lattice[:, 0]
+        a2 = lattice[:, 1]
+        len_a1[i] = np.linalg.norm(a1)
+        len_a2[i] = np.linalg.norm(a2)
+        gamma_list[i] = angle_between_deg(a1, a2)
+        theta_list[i] = float(np.mod(np.degrees(np.arctan2(a1[1], a1[0])), 180.0))
+
+    gamma_star = angle_mode_deg(gamma_list, 1.0)
+    if not np.isfinite(gamma_star):
+        gamma_star = float(gamma_deg_guess)
+    theta_star = angle_mode_deg(theta_list, 1.0)
+    if not np.isfinite(theta_star):
+        theta_star = 0.0
+    ax_star = length_mode_px(len_a1)
+    if not np.isfinite(ax_star):
+        ax_star = float(ax_px_guess)
+    ay_star = length_mode_px(len_a2)
+    if not np.isfinite(ay_star):
+        ay_star = float(ay_px_guess)
+
+    tol_gamma = max(params.min_tol_deg, params.wiggle_pct * max(gamma_star, 1.0))
+    tol_theta = max(params.min_tol_deg, params.wiggle_pct * max(theta_star, 1.0))
+    len_slack = max(0.05, params.wiggle_pct)
+
+    u1_lock = np.array([np.cos(np.radians(theta_star)), np.sin(np.radians(theta_star))])
+    u2_lock = np.array(
+        [
+            np.cos(np.radians(theta_star + gamma_star)),
+            np.sin(np.radians(theta_star + gamma_star)),
+        ]
+    )
+    a1_lock = ax_star * u1_lock
+    a2_lock = ay_star * u2_lock
+
+    phi0 = np.array([0.5, 0.5])
+    base0 = np.array([1.0, 1.0]) + phi0[0] * a1_lock + phi0[1] * a2_lock
+    n_range, m_range = nm_cover_image((height, width), base0, a1_lock, a2_lock, params.cover_margin)
+    nn_glob, mm_glob = np.meshgrid(n_range, m_range)
+    nn_glob = nn_glob.ravel()
+    mm_glob = mm_glob.ravel()
+
+    if nn_glob.size > params.max_sites_per_frame:
+        idx = np.linspace(0, nn_glob.size - 1, params.max_sites_per_frame, dtype=int)
+        nn_glob = nn_glob[idx]
+        mm_glob = mm_glob[idx]
+
+    r_spot_locked = int(max(1, round(params.spot_radius_frac * min(ax_star, ay_star))))
+
+    phi_ref = np.array([0.0, 0.0])
+    base_ref = np.array([1.0, 1.0]) + phi_ref[0] * a1_lock + phi_ref[1] * a2_lock
+    xy_ref = np.column_stack(
+        [
+            base_ref[0] + nn_glob * a1_lock[0] + mm_glob * a2_lock[0],
+            base_ref[1] + nn_glob * a1_lock[1] + mm_glob * a2_lock[1],
+        ]
+    )
+    min_x, min_y = np.floor(np.min(xy_ref, axis=0)).astype(int)
+    max_x, max_y = np.ceil(np.max(xy_ref, axis=0)).astype(int)
+    pad_canvas = int(np.ceil(np.linalg.norm(a1_lock) + np.linalg.norm(a2_lock))) + r_spot_locked + 2
+    min_xc = min_x - pad_canvas
+    min_yc = min_y - pad_canvas
+    max_xc = max_x + pad_canvas
+    max_yc = max_y + pad_canvas
+    canvas_width = max(1, max_xc - min_xc + 1)
+    canvas_height = max(1, max_yc - min_yc + 1)
+    shift_canvas = (min_xc, min_yc)
+
+    sxspath = str(folder / f"{base}_artificial_lattice_SxS.mp4")
+    onlypath = str(folder / f"{base}_artificial_lattice_only.mp4")
+    side_writer = imageio.get_writer(sxspath, fps=fps)
+    only_writer = imageio.get_writer(onlypath, fps=fps)
+
+    occ_frames: List[FrameBundle] = []
+    prev_phi = np.array([0.5, 0.5])
+    fwhm_all_px: List[float] = []
+    fwhm_all_a: List[float] = []
+
+    probe_r_px = 0.5 * params.fwhm_probe_diam_a * px_per_a
+
+    for i, image in enumerate(frames):
+        enh = enhance_dog(image, *params.gauss_lo_hi)
+        g1, g2 = _fft_pair_lock(
+            enh,
+            ax_star,
+            ay_star,
+            gamma_star,
+            theta_star,
+            len_slack,
+            tol_gamma,
+            tol_theta,
+            params,
+        )
+        if g1 is None or g2 is None:
+            u1 = np.array([np.cos(np.radians(theta_star)), np.sin(np.radians(theta_star))])
+            u2 = np.array(
+                [
+                    np.cos(np.radians(theta_star + gamma_star)),
+                    np.sin(np.radians(theta_star + gamma_star)),
+                ]
+            )
+            g1 = u1 / max(ax_star, 1e-9)
+            g2 = u2 / max(ay_star, 1e-9)
+        lattice = np.linalg.pinv(np.vstack([g1, g2]))
+        a1_pf = lattice[:, 0]
+        a2_pf = lattice[:, 1]
+        ax_pf = float(np.linalg.norm(a1_pf))
+        ay_pf = float(np.linalg.norm(a2_pf))
+        if not np.isfinite(ax_pf) or ax_pf <= 0 or not np.isfinite(ay_pf) or ay_pf <= 0:
+            a1_pf = a1_lock
+            a2_pf = a2_lock
+
+        best_score = -np.inf
+        best_phi = prev_phi
+        K = params.phase_grid
+        offsets = np.linspace(0, 1, K, endpoint=False)
+        for p1 in offsets:
+            for p2 in offsets:
+                phi = np.array([p1, p2])
+                base_pf = np.array([1.0, 1.0]) + phi[0] * a1_pf + phi[1] * a2_pf
+                xy_pf = np.column_stack(
+                    [
+                        base_pf[0] + nn_glob * a1_pf[0] + mm_glob * a2_pf[0],
+                        base_pf[1] + nn_glob * a1_pf[1] + mm_glob * a2_pf[1],
+                    ]
+                )
+                mask = (
+                    (xy_pf[:, 0] >= 1)
+                    & (xy_pf[:, 0] <= width)
+                    & (xy_pf[:, 1] >= 1)
+                    & (xy_pf[:, 1] <= height)
+                )
+                if not np.any(mask):
+                    continue
+                score = float(np.sum(sample_at_points(enh, xy_pf[mask])))
+                if score > best_score:
+                    best_score = score
+                    best_phi = phi
+        prev_phi = best_phi
+
+        base_pf = np.array([1.0, 1.0]) + best_phi[0] * a1_pf + best_phi[1] * a2_pf
+        xy_pf = np.column_stack(
+            [
+                base_pf[0] + nn_glob * a1_pf[0] + mm_glob * a2_pf[0],
+                base_pf[1] + nn_glob * a1_pf[1] + mm_glob * a2_pf[1],
+            ]
+        )
+        t_pix = best_phi[0] * a1_pf + best_phi[1] * a2_pf
+        phi_star = np.linalg.lstsq(np.column_stack([a1_lock, a2_lock]), t_pix, rcond=None)[0]
+        base_lock = np.array([1.0, 1.0]) + phi_star[0] * a1_lock + phi_star[1] * a2_lock
+        xy_lock = np.column_stack(
+            [
+                base_lock[0] + nn_glob * a1_lock[0] + mm_glob * a2_lock[0],
+                base_lock[1] + nn_glob * a1_lock[1] + mm_glob * a2_lock[1],
+            ]
+        )
+        in_img = (
+            (xy_lock[:, 0] >= 1)
+            & (xy_lock[:, 0] <= width)
+            & (xy_lock[:, 1] >= 1)
+            & (xy_lock[:, 1] <= height)
+        )
+        xy_lock_in = xy_lock[in_img]
+        xy_pf_in = xy_pf[in_img]
+
+        occ_in, fwhm_px = _adsorbates_from_fwhm(
+            image,
+            xy_pf_in,
+            probe_r_px,
+            r_spot_locked,
+            params,
+        )
+        valid = np.isfinite(fwhm_px)
+        fwhm_all_px.extend(fwhm_px[valid])
+        fwhm_all_a.extend(fwhm_px[valid] * a_per_px)
+
+        xy_canvas = np.column_stack(
+            [xy_lock[:, 0] - shift_canvas[0] + 1, xy_lock[:, 1] - shift_canvas[1] + 1]
+        )
+        art = np.zeros((canvas_height, canvas_width), dtype=float)
+        if xy_canvas.size:
+            art = draw_spots(art, xy_canvas, r_spot_locked, params.gray_dark)
+            if np.any(in_img) and np.any(occ_in == 1):
+                art = draw_spots(art, xy_canvas[in_img & (occ_in == 1)], r_spot_locked, params.gray_light)
+        art = np.clip(art, 0, 1)
+        art_rgb = np.repeat((art * 255).astype(np.uint8)[..., None], 3, axis=2)
+
+        left = image
+        if left.shape[0] < canvas_height:
+            pad_total = canvas_height - left.shape[0]
+            pad_top = pad_total // 2
+            pad_bottom = pad_total - pad_top
+            left = np.pad(left, ((pad_top, pad_bottom), (0, 0)), mode="edge")
+        elif left.shape[0] > canvas_height:
+            start = (left.shape[0] - canvas_height) // 2
+            left = left[start : start + canvas_height, :]
+        combo = np.concatenate([left, art], axis=1)
+        combo = np.clip(combo, 0, 1)
+        combo_rgb = np.repeat((combo * 255).astype(np.uint8)[..., None], 3, axis=2)
+
+        side_writer.write(combo_rgb)
+        only_writer.write(art_rgb)
+
+        bundle = FrameBundle(
+            nodes_px_locked=xy_lock_in,
+            nodes_px_measured=xy_pf_in,
+            occ=occ_in.astype(float),
+            fwhm_px=fwhm_px,
+            a_len_px_pf=(ax_pf, ay_pf),
+            a_len_px_locked=(ax_star, ay_star),
+            r_spot=r_spot_locked,
+            phi_pf=(float(best_phi[0]), float(best_phi[1])),
+            phi_locked=(float(phi_star[0]), float(phi_star[1])),
+        )
+        occ_frames.append(bundle)
+
+    side_writer.close()
+    only_writer.close()
+
+    png_a = None
+    png_p = None
+    if params.export_fwhm_hists and fwhm_all_px:
+        png_a = str(folder / f"{base}_fwhm_hist_A.png")
+        png_p = str(folder / f"{base}_fwhm_hist_px.png")
+        _save_histogram(np.array(fwhm_all_a), "FWHM (Å)", png_a, base)
+        _save_histogram(np.array(fwhm_all_px), "FWHM (px)", png_p, base)
+
+    occ_serialised = [
+        {
+            "nodes_px_locked": bundle.nodes_px_locked,
+            "nodes_px_measured": bundle.nodes_px_measured,
+            "occ": bundle.occ,
+            "fwhm_px": bundle.fwhm_px,
+            "a_len_px_pf": np.array(bundle.a_len_px_pf, dtype=float),
+            "a_len_px_locked": np.array(bundle.a_len_px_locked, dtype=float),
+            "r_spot": bundle.r_spot,
+            "phi_pf": np.array(bundle.phi_pf, dtype=float),
+            "phi_locked": np.array(bundle.phi_locked, dtype=float),
+        }
+        for bundle in occ_frames
+    ]
+
+    data = {
+        "vidPath": str(vid_path),
+        "fps": fps,
+        "P": asdict(params),
+        "ax_A": ax_a,
+        "ay_A": ay_a,
+        "gamma_deg_guess": gamma_deg_guess,
+        "ax_px_guess": ax_px_guess,
+        "ay_px_guess": ay_px_guess,
+        "nm_per_px": nm_per_px,
+        "occFrames": np.array(occ_serialised, dtype=object),
+        "sxspath": sxspath,
+        "onlypath": onlypath,
+        "ax_star": ax_star,
+        "ay_star": ay_star,
+        "gamma_star": gamma_star,
+        "theta_star": theta_star,
+        "FWHM_all_px": np.array(fwhm_all_px),
+        "FWHM_all_A": np.array(fwhm_all_a),
+        "pngA": png_a or "",
+        "pngP": png_p or "",
+        "Hc": canvas_height,
+        "Wc": canvas_width,
+        "shiftCanvas": np.array(shift_canvas),
+        "frame_shape": np.array([height, width]),
+    }
+    savemat(folder / "lattice_occupancy_locked.mat", data)
+
+    return BundleOutputs(
+        occ_frames=occ_frames,
+        fps=fps,
+        params=params,
+        ax_star=ax_star,
+        ay_star=ay_star,
+        gamma_star=gamma_star,
+        theta_star=theta_star,
+        nm_per_px=nm_per_px,
+        sxspath=sxspath,
+        onlypath=onlypath,
+        fwhm_all_px=np.array(fwhm_all_px),
+        fwhm_all_a=np.array(fwhm_all_a),
+        png_a=png_a,
+        png_p=png_p,
+        canvas_height=canvas_height,
+        canvas_width=canvas_width,
+        shift_canvas=shift_canvas,
+        frame_shape=(height, width),
+    )
+
+
+def _fft_pair_scan(
+    image: np.ndarray,
+    ax_px: float,
+    ay_px: float,
+    gamma_deg: float,
+    params: LatticeParams,
+) -> Tuple[np.ndarray | None, np.ndarray | None]:
+    r1 = 1.0 / max(ax_px, 1e-9)
+    r2 = 1.0 / max(ay_px, 1e-9)
+    _, freqs, values = gaussian_fft_peaks(
+        image,
+        r1,
+        r2,
+        params.ring_slack_scan,
+        params.top_k_per_band,
+    )
+    best = -np.inf
+    best_pair: Tuple[np.ndarray | None, np.ndarray | None] = (None, None)
+    for i in range(len(freqs)):
+        for j in range(i + 1, len(freqs)):
+            u = freqs[i]
+            v = freqs[j]
+            lattice = np.linalg.pinv(np.vstack([u, v]))
+            if not np.all(np.isfinite(lattice)):
+                continue
+            a1 = lattice[:, 0]
+            a2 = lattice[:, 1]
+            gamma = angle_between_deg(a1, a2)
+            diff = angle_diff_deg(gamma, gamma_deg)
+            if diff > 25:
+                continue
+            score = (values[i] + values[j]) / (1 + (diff / 10) ** 2)
+            if score > best:
+                best = score
+                best_pair = (u, v)
+    if best_pair[0] is None:
+        angles = np.mod(np.degrees(np.arctan2(freqs[:, 1], freqs[:, 0])), 180.0)
+        best = -np.inf
+        for i in range(len(freqs)):
+            for j in range(i + 1, len(freqs)):
+                sep = min(abs(angles[i] - angles[j]), 180.0 - abs(angles[i] - angles[j]))
+                if sep < 25:
+                    continue
+                score = values[i] + values[j]
+                if score > best:
+                    best = score
+                    best_pair = (freqs[i], freqs[j])
+    if best_pair[0] is None:
+        return None, None
+    return np.array(best_pair[0]), np.array(best_pair[1])
+
+
+def _fft_pair_lock(
+    image: np.ndarray,
+    ax_star: float,
+    ay_star: float,
+    gamma_star: float,
+    theta_star: float,
+    len_slack: float,
+    tol_gamma: float,
+    tol_theta: float,
+    params: LatticeParams,
+) -> Tuple[np.ndarray | None, np.ndarray | None]:
+    r1 = 1.0 / max(ax_star, 1e-9)
+    r2 = 1.0 / max(ay_star, 1e-9)
+    _, freqs, values = gaussian_fft_peaks(
+        image,
+        r1,
+        r2,
+        len_slack,
+        params.top_k_per_band,
+    )
+    best = -np.inf
+    best_pair: Tuple[np.ndarray | None, np.ndarray | None] = (None, None)
+    for i in range(len(freqs)):
+        for j in range(i + 1, len(freqs)):
+            u = freqs[i]
+            v = freqs[j]
+            lattice = np.linalg.pinv(np.vstack([u, v]))
+            if not np.all(np.isfinite(lattice)):
+                continue
+            a1 = lattice[:, 0]
+            a2 = lattice[:, 1]
+            ax_t = np.linalg.norm(a1)
+            ay_t = np.linalg.norm(a2)
+            if abs(ax_t - ax_star) / ax_star > len_slack:
+                continue
+            if abs(ay_t - ay_star) / ay_star > len_slack:
+                continue
+            gamma = angle_between_deg(a1, a2)
+            theta = np.mod(np.degrees(np.arctan2(a1[1], a1[0])), 180.0)
+            if angle_diff_deg(gamma, gamma_star) > tol_gamma:
+                continue
+            if angle_diff_deg(theta, theta_star) > tol_theta:
+                continue
+            penal = 1 + 0.5 * (angle_diff_deg(gamma, gamma_star) / tol_gamma) ** 2
+            penal += 0.5 * (angle_diff_deg(theta, theta_star) / tol_theta) ** 2
+            penal += 0.25 * ((ax_t - ax_star) / (len_slack * ax_star)) ** 2
+            penal += 0.25 * ((ay_t - ay_star) / (len_slack * ay_star)) ** 2
+            score = (values[i] + values[j]) / penal
+            if score > best:
+                best = score
+                best_pair = (u, v)
+    if best_pair[0] is None:
+        u1 = np.array([np.cos(np.radians(theta_star)), np.sin(np.radians(theta_star))])
+        u2 = np.array(
+            [
+                np.cos(np.radians(theta_star + gamma_star)),
+                np.sin(np.radians(theta_star + gamma_star)),
+            ]
+        )
+        return u1 / max(ax_star, 1e-9), u2 / max(ay_star, 1e-9)
+    return np.array(best_pair[0]), np.array(best_pair[1])
+
+
+def _adsorbates_from_fwhm(
+    image: np.ndarray,
+    xy_pf_in: np.ndarray,
+    probe_r_px: float,
+    r_spot_locked: int,
+    params: LatticeParams,
+) -> Tuple[np.ndarray, np.ndarray]:
+    occ = np.zeros(len(xy_pf_in), dtype=int)
+    fwhm_px = np.full(len(xy_pf_in), np.nan)
+    if len(xy_pf_in) == 0:
+        return occ, fwhm_px
+
+    height, width = image.shape
+    r_max = max(
+        int(round(min(min(width, height) * 0.05, 10 * max(1, probe_r_px)))),
+        r_spot_locked * 2,
+    )
+    dr = params.fwhm_dr_px
+
+    for idx, (cx, cy) in enumerate(xy_pf_in):
+        xmin = max(0, int(np.floor(cx - r_max)))
+        xmax = min(width - 1, int(np.ceil(cx + r_max)))
+        ymin = max(0, int(np.floor(cy - r_max)))
+        ymax = min(height - 1, int(np.ceil(cy + r_max)))
+        if xmin > xmax or ymin > ymax:
+            continue
+        xs = np.arange(xmin, xmax + 1)
+        ys = np.arange(ymin, ymax + 1)
+        xx, yy = np.meshgrid(xs, ys)
+        rr = np.hypot(xx - cx, yy - cy)
+        block = image[ymin : ymax + 1, xmin : xmax + 1]
+        rvals = rr.ravel()
+        ivals = block.ravel()
+        nbins = max(3, int(np.ceil(np.max(rvals) / dr)))
+        edges = np.linspace(0, nbins * dr, nbins + 1)
+        bin_idx = np.minimum(nbins - 1, (rvals / dr).astype(int))
+        prof_sum = np.bincount(bin_idx, weights=ivals, minlength=nbins)
+        prof_cnt = np.bincount(bin_idx, minlength=nbins)
+        with np.errstate(invalid="ignore"):
+            prof = prof_sum / np.maximum(prof_cnt, 1)
+        rmid = (edges[:-1] + edges[1:]) * 0.5
+        if not np.isfinite(prof[0]) or np.sum(np.isfinite(prof)) < 3:
+            continue
+        tail_start = max(0, int(round((1 - params.fwhm_outer_frac) * len(prof))))
+        baseline = np.nanmedian(prof[tail_start:])
+        if not np.isfinite(baseline):
+            baseline = np.nanmin(prof)
+        peak = prof[0]
+        if not np.isfinite(peak):
+            continue
+        half = baseline + 0.5 * (peak - baseline)
+        finite_mask = np.isfinite(prof)
+        indices = np.where((prof <= half) & finite_mask)[0]
+        if len(indices) == 0 or indices[0] == 0:
+            continue
+        idx0 = indices[0]
+        x1 = rmid[idx0 - 1]
+        x2 = rmid[idx0]
+        y1 = prof[idx0 - 1]
+        y2 = prof[idx0]
+        if not np.isfinite(y1) or not np.isfinite(y2) or y2 == y1:
+            continue
+        t = (half - y1) / (y2 - y1)
+        r_hwhm = x1 + t * (x2 - x1)
+        fwhm_px[idx] = max(0.0, 2.0 * r_hwhm)
+
+    valid = np.isfinite(fwhm_px)
+    if np.sum(valid) >= 4:
+        labels, centers = kmeans_1d(fwhm_px[valid], 2)
+        idx_small = int(np.argmin(centers))
+        occ_valid = labels == idx_small
+        occ[valid] = occ_valid.astype(int)
+        if np.sum(occ) < params.min_occ_for_frame:
+            order = np.argsort(fwhm_px[valid])
+            k = max(params.top_min_rescue, int(round(params.top_frac_rescue * np.sum(valid))))
+            occ[:] = 0
+            occ_idx = np.where(valid)[0][order[: min(k, len(order))]]
+            occ[occ_idx] = 1
+    elif np.any(valid):
+        order = np.argsort(fwhm_px[valid])
+        k = max(params.top_min_rescue, int(round(params.top_frac_rescue * np.sum(valid))))
+        occ_idx = np.where(valid)[0][order[: min(k, len(order))]]
+        occ[occ_idx] = 1
+
+    return occ, fwhm_px
+
+
+def _save_histogram(data: np.ndarray, xlabel: str, path: str, base: str) -> None:
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots(figsize=(6, 4), dpi=120)
+    ax.hist(data, bins="fd")
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel("Count")
+    ax.set_title(f"{base} – FWHM distribution (all frames)")
+    ax.grid(True)
+    fig.tight_layout()
+    fig.savefig(path)
+    plt.close(fig)

--- a/track_adsorbates/ui.py
+++ b/track_adsorbates/ui.py
@@ -1,0 +1,162 @@
+"""Simple Tkinter GUI for the adsorbate diffusion analysis pipeline."""
+from __future__ import annotations
+
+import threading
+import tkinter as tk
+from pathlib import Path
+from tkinter import filedialog, messagebox
+from typing import Dict
+
+from .analysis import analyze_adsorbate_diffusion
+
+
+class AnalysisGUI:
+    def __init__(self) -> None:
+        self.root = tk.Tk()
+        self.root.title("Adsorbate Diffusion Analysis")
+        self.root.geometry("480x420")
+        self.root.resizable(False, False)
+
+        self.video_folder_var = tk.StringVar()
+        self.video_name_var = tk.StringVar()
+        self.video_file_var = tk.StringVar()
+        self.width_nm_var = tk.StringVar(value="10.0")
+        self.ax_var = tk.StringVar(value="3.0")
+        self.ay_var = tk.StringVar(value="3.0")
+        self.gamma_var = tk.StringVar(value="60.0")
+        self.probe_var = tk.StringVar(value="1.5")
+        self.max_frames_var = tk.StringVar(value="")
+        self.status_var = tk.StringVar(value="Idle")
+
+        self._build_ui()
+
+    def _build_ui(self) -> None:
+        frame = tk.Frame(self.root, padx=12, pady=12)
+        frame.pack(fill=tk.BOTH, expand=True)
+
+        row = 0
+        tk.Label(frame, text="Video folder:").grid(row=row, column=0, sticky="w")
+        entry_folder = tk.Entry(frame, textvariable=self.video_folder_var, width=40)
+        entry_folder.grid(row=row, column=1, sticky="ew", padx=(6, 6))
+        tk.Button(frame, text="Browse", command=self._browse_folder).grid(row=row, column=2, sticky="ew")
+
+        row += 1
+        tk.Label(frame, text="Video file name:").grid(row=row, column=0, sticky="w")
+        tk.Entry(frame, textvariable=self.video_name_var, width=40).grid(row=row, column=1, columnspan=2, sticky="ew", padx=(6, 6))
+
+        row += 1
+        tk.Label(frame, text="Or choose file directly:").grid(row=row, column=0, sticky="w")
+        tk.Entry(frame, textvariable=self.video_file_var, width=40).grid(row=row, column=1, sticky="ew", padx=(6, 6))
+        tk.Button(frame, text="Browse", command=self._browse_file).grid(row=row, column=2, sticky="ew")
+
+        separators = [
+            ("Video width (nm):", self.width_nm_var),
+            ("a₁ spacing (Å):", self.ax_var),
+            ("a₂ spacing (Å):", self.ay_var),
+            ("γ between a₁/a₂ (deg):", self.gamma_var),
+            ("Probe diameter (Å):", self.probe_var),
+            ("Max frames (optional):", self.max_frames_var),
+        ]
+
+        for label_text, variable in separators:
+            row += 1
+            tk.Label(frame, text=label_text).grid(row=row, column=0, sticky="w")
+            tk.Entry(frame, textvariable=variable, width=15).grid(row=row, column=1, sticky="w", padx=(6, 6))
+
+        row += 1
+        tk.Button(frame, text="Run analysis", command=self._run_analysis).grid(row=row, column=0, columnspan=3, pady=(12, 6), sticky="ew")
+
+        row += 1
+        tk.Label(frame, textvariable=self.status_var, anchor="w").grid(row=row, column=0, columnspan=3, sticky="ew")
+
+        frame.columnconfigure(1, weight=1)
+
+    def _browse_folder(self) -> None:
+        folder = filedialog.askdirectory(title="Select video folder")
+        if folder:
+            self.video_folder_var.set(folder)
+
+    def _browse_file(self) -> None:
+        file_path = filedialog.askopenfilename(title="Select AFM video", filetypes=[("Video files", "*.mp4 *.avi *.mov *.mkv"), ("All files", "*.*")])
+        if file_path:
+            self.video_file_var.set(file_path)
+            self.video_folder_var.set(str(Path(file_path).parent))
+            self.video_name_var.set(Path(file_path).name)
+
+    def _run_analysis(self) -> None:
+        try:
+            params = self._collect_parameters()
+        except ValueError as exc:
+            messagebox.showerror("Invalid input", str(exc))
+            return
+
+        self.status_var.set("Running analysis…")
+        self.root.update_idletasks()
+
+        thread = threading.Thread(target=self._execute_analysis, args=(params,), daemon=True)
+        thread.start()
+
+    def _collect_parameters(self) -> Dict[str, object]:
+        video_file = self.video_file_var.get().strip()
+        if video_file:
+            video_path = Path(video_file)
+        else:
+            folder = self.video_folder_var.get().strip()
+            name = self.video_name_var.get().strip()
+            if not folder or not name:
+                raise ValueError("Please provide a video file or folder and filename.")
+            video_path = Path(folder) / name
+        if not video_path.exists():
+            raise ValueError(f"Video file not found: {video_path}")
+
+        try:
+            width_nm = float(self.width_nm_var.get())
+            ax = float(self.ax_var.get())
+            ay = float(self.ay_var.get())
+            gamma = float(self.gamma_var.get())
+            probe = float(self.probe_var.get()) if self.probe_var.get() else None
+            max_frames = int(self.max_frames_var.get()) if self.max_frames_var.get() else None
+        except ValueError as exc:
+            raise ValueError("Numeric fields must contain valid numbers.") from exc
+
+        if width_nm <= 0 or ax <= 0 or ay <= 0:
+            raise ValueError("Video width and lattice spacings must be positive.")
+
+        return {
+            "vid_path": str(video_path),
+            "vid_width_nm": width_nm,
+            "ax_a": ax,
+            "ay_a": ay,
+            "gamma_deg_guess": gamma,
+            "probe_diam_a": probe,
+            "max_frames": max_frames,
+        }
+
+    def _execute_analysis(self, params: Dict[str, object]) -> None:
+        try:
+            results = analyze_adsorbate_diffusion(**params)
+        except Exception as exc:  # noqa: BLE001
+            self.status_var.set("Analysis failed. See console for details.")
+            messagebox.showerror("Analysis failed", str(exc))
+            raise
+        else:
+            msg = (
+                f"D = {results.D:.4g} nm²/s\n"
+                f"Steps used: {results.N_steps}\n"
+                f"Δt = {results.delta_t:.4g} s"
+            )
+            self.status_var.set("Analysis completed successfully.")
+            messagebox.showinfo("Analysis complete", msg)
+
+    def run(self) -> None:
+        self.root.mainloop()
+
+
+def launch_gui() -> None:
+    """Launch the Tkinter GUI."""
+    gui = AnalysisGUI()
+    gui.run()
+
+
+if __name__ == "__main__":
+    launch_gui()

--- a/track_adsorbates/ui.py
+++ b/track_adsorbates/ui.py
@@ -1,13 +1,18 @@
 """Simple Tkinter GUI for the adsorbate diffusion analysis pipeline."""
 from __future__ import annotations
 
+import sys
 import threading
 import tkinter as tk
 from pathlib import Path
 from tkinter import filedialog, messagebox
 from typing import Dict
 
-from .analysis import analyze_adsorbate_diffusion
+if __package__ in (None, ""):
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+    from track_adsorbates.analysis import analyze_adsorbate_diffusion
+else:
+    from .analysis import analyze_adsorbate_diffusion
 
 
 class AnalysisGUI:

--- a/track_adsorbates/ui.py
+++ b/track_adsorbates/ui.py
@@ -19,11 +19,9 @@ class AnalysisGUI:
     def __init__(self) -> None:
         self.root = tk.Tk()
         self.root.title("Adsorbate Diffusion Analysis")
-        self.root.geometry("480x420")
+        self.root.geometry("460x320")
         self.root.resizable(False, False)
 
-        self.video_folder_var = tk.StringVar()
-        self.video_name_var = tk.StringVar()
         self.video_file_var = tk.StringVar()
         self.width_nm_var = tk.StringVar(value="10.0")
         self.ax_var = tk.StringVar(value="3.0")
@@ -40,18 +38,10 @@ class AnalysisGUI:
         frame.pack(fill=tk.BOTH, expand=True)
 
         row = 0
-        tk.Label(frame, text="Video folder:").grid(row=row, column=0, sticky="w")
-        entry_folder = tk.Entry(frame, textvariable=self.video_folder_var, width=40)
-        entry_folder.grid(row=row, column=1, sticky="ew", padx=(6, 6))
-        tk.Button(frame, text="Browse", command=self._browse_folder).grid(row=row, column=2, sticky="ew")
-
-        row += 1
-        tk.Label(frame, text="Video file name:").grid(row=row, column=0, sticky="w")
-        tk.Entry(frame, textvariable=self.video_name_var, width=40).grid(row=row, column=1, columnspan=2, sticky="ew", padx=(6, 6))
-
-        row += 1
-        tk.Label(frame, text="Or choose file directly:").grid(row=row, column=0, sticky="w")
-        tk.Entry(frame, textvariable=self.video_file_var, width=40).grid(row=row, column=1, sticky="ew", padx=(6, 6))
+        tk.Label(frame, text="Video file:").grid(row=row, column=0, sticky="w")
+        tk.Entry(frame, textvariable=self.video_file_var, width=40).grid(
+            row=row, column=1, sticky="ew", padx=(6, 6)
+        )
         tk.Button(frame, text="Browse", command=self._browse_file).grid(row=row, column=2, sticky="ew")
 
         separators = [
@@ -76,17 +66,10 @@ class AnalysisGUI:
 
         frame.columnconfigure(1, weight=1)
 
-    def _browse_folder(self) -> None:
-        folder = filedialog.askdirectory(title="Select video folder")
-        if folder:
-            self.video_folder_var.set(folder)
-
     def _browse_file(self) -> None:
         file_path = filedialog.askopenfilename(title="Select AFM video", filetypes=[("Video files", "*.mp4 *.avi *.mov *.mkv"), ("All files", "*.*")])
         if file_path:
             self.video_file_var.set(file_path)
-            self.video_folder_var.set(str(Path(file_path).parent))
-            self.video_name_var.set(Path(file_path).name)
 
     def _run_analysis(self) -> None:
         try:
@@ -103,14 +86,9 @@ class AnalysisGUI:
 
     def _collect_parameters(self) -> Dict[str, object]:
         video_file = self.video_file_var.get().strip()
-        if video_file:
-            video_path = Path(video_file)
-        else:
-            folder = self.video_folder_var.get().strip()
-            name = self.video_name_var.get().strip()
-            if not folder or not name:
-                raise ValueError("Please provide a video file or folder and filename.")
-            video_path = Path(folder) / name
+        if not video_file:
+            raise ValueError("Please choose a video file to analyze.")
+        video_path = Path(video_file)
         if not video_path.exists():
             raise ValueError(f"Video file not found: {video_path}")
 
@@ -148,7 +126,8 @@ class AnalysisGUI:
             msg = (
                 f"D = {results.D:.4g} nm²/s\n"
                 f"Steps used: {results.N_steps}\n"
-                f"Δt = {results.delta_t:.4g} s"
+                f"Δt = {results.delta_t:.4g} s\n"
+                f"Saved to: {results.results_path}"
             )
             self.status_var.set("Analysis completed successfully.")
             messagebox.showinfo("Analysis complete", msg)


### PR DESCRIPTION
## Summary
- port the lattice-locking and adsorbate classification workflow to Python, including DoG enhancement, FFT peak selection, FWHM histograms, and artificial-lattice video export
- implement the diffusion analysis pipeline with drift correction, greedy hop assignment, and MATLAB-compatible `.mat` outputs
- add a Tkinter GUI for selecting videos and parameters plus README usage instructions

## Testing
- python -m compileall track_adsorbates

------
https://chatgpt.com/codex/tasks/task_b_68d68dbfbbec832cbc3e58600e151c25